### PR TITLE
Add case insensitivity to database

### DIFF
--- a/db/migrate/20160414140445_add_citext_type_to_tables.rb
+++ b/db/migrate/20160414140445_add_citext_type_to_tables.rb
@@ -1,0 +1,13 @@
+class AddCitextTypeToTables < ActiveRecord::Migration
+  enable_extension("citext")
+
+  def change
+    change_column :customers,    :first_name,  :citext
+    change_column :customers,    :last_name,   :citext
+    change_column :invoices,     :status,      :citext
+    change_column :items,        :name,        :citext
+    change_column :items,        :description, :citext
+    change_column :merchants,    :name,        :citext
+    change_column :transactions, :result,      :citext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160412041058) do
+ActiveRecord::Schema.define(version: 20160414140445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "citext"
 
   create_table "customers", force: :cascade do |t|
-    t.string   "first_name"
-    t.string   "last_name"
+    t.citext   "first_name"
+    t.citext   "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -35,14 +36,14 @@ ActiveRecord::Schema.define(version: 20160412041058) do
   create_table "invoices", force: :cascade do |t|
     t.integer  "customer_id"
     t.integer  "merchant_id"
-    t.string   "status"
+    t.citext   "status"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
 
   create_table "items", force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
+    t.citext   "name"
+    t.citext   "description"
     t.integer  "unit_price"
     t.integer  "merchant_id"
     t.datetime "created_at",  null: false
@@ -50,7 +51,7 @@ ActiveRecord::Schema.define(version: 20160412041058) do
   end
 
   create_table "merchants", force: :cascade do |t|
-    t.string   "name"
+    t.citext   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -58,7 +59,7 @@ ActiveRecord::Schema.define(version: 20160412041058) do
   create_table "transactions", force: :cascade do |t|
     t.integer  "invoice_id"
     t.string   "credit_card_number"
-    t.string   "result"
+    t.citext   "result"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
   end


### PR DESCRIPTION
Changed all text type columns in the database to citext types.
As of Rails 4.2 citext is supported out of the box

Closes #96